### PR TITLE
Refactor asset.psm1

### DIFF
--- a/asset.psm1
+++ b/asset.psm1
@@ -29,23 +29,14 @@ function Get-MonitorInformation {
                 expression = { $psitem.__SERVER }
             },
             @{  name = 'Name'
-                expression = {convertUint16ToString $psitem.ManufacturerName}
+                expression = { [System.Text.Encoding]::ASCII.GetString($psitem.ManufacturerName) }
             },
             @{  name = 'Serial'
-                expression = {convertUint16ToString $psitem.SerialNumberID}
+                expression = { [System.Text.Encoding]::ASCII.GetString($psitem.SerialNumberID) }
             },
             YearOfManufacture
 
     }
-}
-
-function convertUint16ToString($int){
-    $str = $int | Where-Object {
-        $_ -notmatch 0
-    } | ForEach-Object {
-        [char]$_
-    }
-    Write-Output ($str -join "")
 }
 
 Export-ModuleMember -Function "Get-MonitorInformation"


### PR DESCRIPTION
convertUint16ToString can be refactored to a single call to [System.Text.Encoding]::ASCII.GetString()
This worked fine in my testing.